### PR TITLE
New connector for Merge (which has zero fees)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -358,6 +358,7 @@ libxbridge_xbridge_a_SOURCES = \
   xbridge/xbridgecryptoproviderbtc.cpp \
   xbridge/xbridgewalletconnectorbch.cpp \
   xbridge/xbridgewalletconnectordgb.cpp \
+  xbridge/xbridgewalletconnectormerge.cpp \
   xbridge/xbitcoinaddress.cpp \
   xbridge/xbitcointransaction.cpp \
   xbridge/rpcxbridge.cpp \
@@ -381,6 +382,7 @@ libxbridge_xbridge_a_SOURCES = \
   xbridge/xbridgecryptoproviderbtc.h \
   xbridge/xbridgewalletconnectorbch.h \
   xbridge/xbridgewalletconnectordgb.h \
+  xbridge/xbridgewalletconnectormerge.h \
   xbridge/xbridgewallet.h \
   xbridge/xuiconnector.h \
   xbridge/util/logger.h \

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -8,6 +8,7 @@
 #include "xbridgecryptoproviderbtc.h"
 #include "xbridgewalletconnectorbch.h"
 #include "xbridgewalletconnectordgb.h"
+#include "xbridgewalletconnectormerge.h"
 #include "xrouter/xrouterapp.h"
 
 #include "util/xutil.h"
@@ -901,7 +902,7 @@ void App::updateActiveWallets()
             wp.m_user.empty() || wp.m_passwd.empty() ||
             wp.COIN == 0 || wp.blockTime == 0)
         {
-            ERR() << wp.currency << " \"" << wp.title << "\"" << " Failed to connect, check the config";
+            ERR() << wp.currency << " \"" << wp.title << "\"" << " Failed to connect (1), check the config";
             removeConnector(wp.currency);
             continue;
         }
@@ -932,6 +933,11 @@ void App::updateActiveWallets()
             conn.reset(new DgbWalletConnector);
             *conn = wp;
         }
+        else if (wp.method == "MERGE")
+        {
+            conn.reset(new MergeWalletConnector);
+            *conn = wp;
+        }
         else
         {
             ERR() << "unknown session type " << __FUNCTION__;
@@ -940,7 +946,7 @@ void App::updateActiveWallets()
         // If the wallet is invalid, remove it from the list
         if (!conn)
         {
-            ERR() << wp.currency << " \"" << wp.title << "\"" << " Failed to connect, check the config";
+            ERR() << wp.currency << " \"" << wp.title << "\"" << " Failed to connect (2), check the config";
             removeConnector(wp.currency);
             continue;
         }
@@ -1047,7 +1053,7 @@ void App::updateActiveWallets()
                     boost::posix_time::ptime time{boost::posix_time::second_clock::universal_time()};
                     m_badWallets[conn->currency] = time;
                 }
-                WARN() << conn->currency << " \"" << conn->title << "\"" << " Failed to connect, check the config";
+                WARN() << conn->currency << " \"" << conn->title << "\"" << " Failed to connect (3), check the config";
             }
         }
     }

--- a/src/xbridge/xbridgewalletconnectormerge.cpp
+++ b/src/xbridge/xbridgewalletconnectormerge.cpp
@@ -1,0 +1,55 @@
+//******************************************************************************
+//******************************************************************************
+
+#include "json/json_spirit_reader_template.h"
+#include "json/json_spirit_writer_template.h"
+#include "json/json_spirit_utils.h"
+
+#include "xbridgewalletconnectormerge.h"
+
+#include "util/logger.h"
+#include "util/txlog.h"
+
+#include "xbitcoinaddress.h"
+#include "xbitcointransaction.h"
+
+//*****************************************************************************
+//*****************************************************************************
+namespace xbridge
+{
+
+//******************************************************************************
+//******************************************************************************
+MergeWalletConnector::MergeWalletConnector()
+    : BtcWalletConnector()
+{
+
+}
+
+//*****************************************************************************
+bool MergeWalletConnector::init()
+{
+    // convert prefixes
+    addrPrefix   = static_cast<char>(std::atoi(addrPrefix.data()));
+    scriptPrefix = static_cast<char>(std::atoi(scriptPrefix.data()));
+    secretPrefix = static_cast<char>(std::atoi(secretPrefix.data()));
+
+    // wallet info
+    rpc::WalletInfo info;
+    if (!this->getInfo(info))
+        return false;
+
+    auto fallbackMinTxFee = static_cast<uint64_t>(info.relayFee * 2 * COIN);
+    if (minTxFee == 0 && feePerByte == 0 && fallbackMinTxFee == 0) { // non-relay fee coin
+        minTxFee = 0; // units (e.g. satoshis for btc)
+        dustAmount = 0;
+        WARN() << currency << " \"" << title << "\"" << " Using minimum/no fee of 0 sats";
+    } else {
+        minTxFee = std::max(fallbackMinTxFee, minTxFee);
+        dustAmount = fallbackMinTxFee > 0 ? fallbackMinTxFee : minTxFee;
+    }
+
+    return true;
+}
+
+} // namespace xbridge

--- a/src/xbridge/xbridgewalletconnectormerge.h
+++ b/src/xbridge/xbridgewalletconnectormerge.h
@@ -1,0 +1,25 @@
+#ifndef XBRIDGEWALLETCONNECTORMERGE_H
+#define XBRIDGEWALLETCONNECTORMERGE_H
+
+#include "xbridgewalletconnectorbtc.h"
+#include "xbridgecryptoproviderbtc.h"
+
+//*****************************************************************************
+//*****************************************************************************
+namespace xbridge
+{
+
+//******************************************************************************
+//******************************************************************************
+class MergeWalletConnector : public BtcWalletConnector<BtcCryptoProvider>
+
+{
+public:
+    MergeWalletConnector();
+
+    bool init();
+};
+
+} // namespace xbridge
+
+#endif // XBRIDGEWALLETCONNECTORMERGE_H


### PR DESCRIPTION
Replacement for [PR #415](https://github.com/blocknetdx/blocknet/pull/415) which used the wrong base.

I tried using the default BTC connector for Merge but there is a hardwired 300k sats fee if the minTxfee and feePerByte are 0. Merge has zero fees and using the BTC connector it rejects all orders from BlockDX.

This new connector doesn't impose any fees above what is configured by the user in the xbridge.conf

While experimenting I encountered a "Failed to connect, check the config" error and couldn't tell which one of 3 checks had caused it so I added a case number to each of the messages to aid debugging.

The connector could be further simplified but I went for the minimum number of changes from the existing code.