### PR TITLE
[core] staking protocol v6

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -115,6 +115,7 @@ public:
         consensus.stakingModiferV2Block = 615800;
         consensus.coinMaturity = 100;
         consensus.stakingV05UpgradeTime = 1569261600; // Sep 23 '19 6pm UTC
+        consensus.stakingV06UpgradeTime = 1586973600; // Apr 15, 2020 6pm UTC
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -276,6 +277,7 @@ public:
         consensus.stakingModiferV2Block = 1;
         consensus.coinMaturity = 15;
         consensus.stakingV05UpgradeTime = 1566085343; // Aug 17, 2019
+        consensus.stakingV06UpgradeTime = 1581628366; // Feb 13, 2020
 
         pchMessageStart[0] = 0x45;
         pchMessageStart[1] = 0x76;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2019-2020 The Blocknet developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -86,7 +87,10 @@ struct Params {
     int stakeMinAge;
     int stakingModiferV2Block;
     int coinMaturity;
+    int64_t stakingPoSTargetTimespan{60*40};
     int64_t stakingV05UpgradeTime{0};
+    int64_t stakingV06UpgradeTime{0};
+    int64_t PoSFutureBlockTimeLimit() const { return nPowTargetSpacing * 3; } // changing this will break consensus!
     /** Service node parameters */
     int snMaxCollateralCount{10}; // max utxos for use with service node collateral
     /** Governance parameters */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -415,7 +415,8 @@ void SetupServerArgs()
     gArgs.AddArg("-prune=<n>", "Pruning is not supported", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex-chainstate", "Rebuild chain state from the currently indexed blocks. When in pruning mode or if blocks on disk might be corrupted, use full -reindex instead.", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-staking", "Mine blocks on this node (default: 1)", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-staking", "Mine blocks on this node (default: 1). Can be used to specify search interval, staking=number_of_seconds (default: 15)", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stakingwithoutpeers", "Proceeds with staking even though no peers were detected. Mainly used for testing, this could put you on a fork. (default: 0)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-minstakeamount", strprintf("Only stakes UTXOs greater than or equal to this amount (default: %d)", 0), false, OptionsCategory::OPTIONS);
 #ifndef WIN32
     gArgs.AddArg("-sysperms", "Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)", false, OptionsCategory::OPTIONS);

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2013 The PPCoin developers
-// Copyright (c) 2017-2019 The Blocknet developers
+// Copyright (c) 2017-2020 The Blocknet developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,36 +11,30 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-// MODIFIER_INTERVAL: time to elapse before new modifier is computed
-static const unsigned int MODIFIER_INTERVAL = 60;
-static const unsigned int MODIFIER_INTERVAL_TESTNET = 60;
-extern unsigned int nModifierInterval;
-extern unsigned int getIntervalVersion(bool fTestNet);
-
-// MODIFIER_INTERVAL_RATIO:
-// ratio of group interval length between the last group and the first group
-static const int MODIFIER_INTERVAL_RATIO = 3;
-
 // Compute the hash modifier for proof-of-stake
-bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
+bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier,
+                              const Consensus::Params & consensus);
 // Stake modifier selection interval
 int64_t GetStakeModifierSelectionInterval();
 
 // Stake modifier selection upgrade
 bool IsProtocolV05(uint64_t nTimeTx);
+bool IsProtocolV06(uint64_t nTimeTx, const Consensus::Params & consensusParams);
 
 uint256 stakeHash(unsigned int nTimeTx, CDataStream ss, unsigned int prevoutIndex, uint256 prevoutHash,unsigned int nTimeBlockFrom);
 uint256 stakeHashV05(CDataStream ss, const unsigned int & nTimeBlockFrom, const int & blockHeight, const unsigned int & prevoutIndex, const unsigned int & nTimeTx);
+uint256 stakeHashV06(CDataStream ss, const uint256 & hashBlockFrom, const unsigned int & nTimeBlockFrom, const int & blockHeight, const unsigned int & prevoutIndex, const unsigned int & nTimeTx);
 
 // Check whether stake kernel meets hash target
-bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, arith_uint256 bnTargetPerCoinDay);
+bool stakeTargetHit(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
+bool stakeTargetHitV06(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
 
-bool CheckStakeKernelHash(const CBlockIndex *pindexPrev, unsigned int nBits, const uint256 txInBlockHash, const int64_t txInBlockTime,
-        const CAmount txInAmount, const COutPoint prevout, unsigned int& nTimeTx, unsigned int nHashDrift, bool fCheck,
-        uint256& hashProofOfStake, bool fPrintProofOfStake = false);
-bool GetKernelStakeModifier(const CBlockIndex *pindexPrev, const uint256 & hashBlockFrom, const unsigned int & nTimeTx, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake);
-bool GetKernelStakeModifierV03(uint256 hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake);
-bool GetKernelStakeModifierBlocknet(const CBlockIndex *pindexPrev, const uint256 & hashBlockFrom, const unsigned int & nTimeTx, uint64_t & nStakeModifier, int & nStakeModifierHeight, int64_t & nStakeModifierTime, bool fPrintProofOfStake);
+bool CheckStakeKernelHash(const CBlockIndex *pindexPrev, const CBlockIndex *pindexStake, const unsigned int & nBits,
+        const CAmount & txInAmount, const COutPoint & prevout, const int64_t & nBlockTime, const unsigned int & nNonce,
+        uint256 & hashProofOfStake, const Consensus::Params & consensus);
+bool GetKernelStakeModifier(const CBlockIndex *pindexPrev, const CBlockIndex *pindexStake, const int64_t & nBlockTime, uint64_t & nStakeModifier, int & nStakeModifierHeight, int64_t & nStakeModifierTime);
+bool GetKernelStakeModifierV03(const CBlockIndex *pindexStake, uint64_t & nStakeModifier, int & nStakeModifierHeight, int64_t & nStakeModifierTime);
+bool GetKernelStakeModifierBlocknet(const CBlockIndex *pindexPrev, const CBlockIndex *pindexStake, const int64_t & blockStakeTime, uint64_t & nStakeModifier, int & nStakeModifierHeight, int64_t & nStakeModifierTime);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
@@ -48,9 +42,6 @@ bool CheckProofOfStake(const CBlockHeader & block, const CBlockIndex *pindexPrev
 
 // peercoin: For use with Staking Protocol V05.
 unsigned int GetStakeEntropyBit(const uint256 & blockHash, const int64_t & blockTime);
-
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
 
 static std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime) {
     // std::locale takes ownership of the pointer

--- a/src/miner.h
+++ b/src/miner.h
@@ -169,8 +169,8 @@ public:
 #ifdef ENABLE_WALLET
     /** Construct new PoS block */
     std::unique_ptr<CBlockTemplate> CreateNewBlockPoS(const CInputCoin & stakeInput, const uint256 & stakeBlockHash,
-                                                      const int64_t & stakeTime, CWallet *keystore,
-                                                      const bool & disableValidationChecks = false);
+                                                      const int64_t & stakeTime, const int64_t & blockTime,
+                                                      CWallet *keystore, const bool & disableValidationChecks = false);
 #endif // ENABLE_WALLET
 
     static Optional<int64_t> m_last_block_num_txs;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
-// Copyright (c) 2017-2019 The Blocknet developers
+// Copyright (c) 2017-2020 The Blocknet developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -15,6 +15,7 @@
 // from kernel.h
 bool IsProofOfStake(int blockHeight);
 bool CheckProofOfStake(const CBlockHeader & block, const CBlockIndex *pindexPrev, uint256 & hashProofOfStake, const Consensus::Params & consensusParams);
+bool IsProtocolV06(uint64_t nTimeTx, const Consensus::Params & consensusParams);
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader */*pblock*/, const Consensus::Params& params)
 {
@@ -161,9 +162,6 @@ unsigned int BlocknetGetNextWorkRequired(const CBlockIndex* pindexLast, const Co
     // Use algo for non-POW blocks
     if (pindexLast->nHeight > params.lastPOWBlock) {
         const arith_uint256 bnTargetLimit = UintToArith256(uint256S("0x000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
-        int64_t nTargetSpacing = 60;
-        int64_t nTargetTimespan = 60 * 40;
-
         int64_t nActualSpacing = 0;
         if (pindexLast->nHeight != 0)
             nActualSpacing = pindexLast->GetBlockTime() - pindexLast->pprev->GetBlockTime();
@@ -176,9 +174,9 @@ unsigned int BlocknetGetNextWorkRequired(const CBlockIndex* pindexLast, const Co
         arith_uint256 bnNew;
         bnNew.SetCompact(pindexLast->nBits);
 
-        int64_t nInterval = nTargetTimespan / nTargetSpacing;
-        bnNew *= ((nInterval - 1) * nTargetSpacing + nActualSpacing + nActualSpacing);
-        bnNew /= ((nInterval + 1) * nTargetSpacing);
+        int64_t nInterval = params.stakingPoSTargetTimespan / params.nPowTargetSpacing;
+        bnNew *= ((nInterval - 1) * params.nPowTargetSpacing + nActualSpacing + nActualSpacing);
+        bnNew /= ((nInterval + 1) * params.nPowTargetSpacing);
 
         if (bnNew <= 0 || bnNew > bnTargetLimit)
             bnNew = bnTargetLimit;

--- a/src/stakemgr.cpp
+++ b/src/stakemgr.cpp
@@ -18,10 +18,11 @@ void ThreadStakeMinter() {
     RenameThread("blocknet-staker");
     LogPrintf("Staker has started\n");
     g_staker = MakeUnique<StakeMgr>();
+    const auto stakingSkipPeers = gArgs.GetBoolArg("-stakingwithoutpeers", false);
+    const auto & chainparams = Params();
     while (!ShutdownRequested()) {
-        const int sleepTimeSeconds{1};
-        if (IsInitialBlockDownload()) { // do not stake during initial download
-            boost::this_thread::sleep_for(boost::chrono::seconds(sleepTimeSeconds));
+        if (!stakingSkipPeers && IsInitialBlockDownload()) { // do not stake during initial download
+            boost::this_thread::sleep_for(boost::chrono::seconds(1));
             continue;
         }
         try {
@@ -31,15 +32,16 @@ void ThreadStakeMinter() {
                 LOCK(cs_main);
                 pindex = chainActive.Tip();
             }
-            if (pindex && g_staker->Update(wallets, pindex, Params().GetConsensus())) {
+            if (pindex && g_staker->Update(wallets, pindex, chainparams.GetConsensus(), stakingSkipPeers)) {
                 boost::this_thread::interruption_point();
-                g_staker->TryStake(pindex, Params());
+                g_staker->TryStake(pindex, chainparams);
             }
         } catch (std::exception & e) {
             LogPrintf("Staker ran into an exception: %s\n", e.what());
         } catch (...) { }
-        boost::this_thread::sleep_for(boost::chrono::seconds(sleepTimeSeconds));
+        boost::this_thread::sleep_for(boost::chrono::seconds(1));
     }
+    g_staker.reset();
     LogPrintf("Staker shutdown\n");
 }
 
@@ -49,14 +51,20 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
     {
         LOCK(cs_main);
         if (!skipPeerRequirement && SyncProgress(chainActive.Height()) < 1.0 - std::numeric_limits<double>::epsilon())
-            return false; /// not ready to stake yet (need to be synced up with peers)
+            return false; // not ready to stake yet (need to be synced up with peers)
     }
-    const int stakeSearchPeriodSeconds{MAX_FUTURE_BLOCK_TIME_POS};
-    const bool notExpired = GetAdjustedTime() <= lastUpdateTime;
+    // Aggressive staking will check inputs at most once per second. If a large number of staking inputs
+    // are not present in the wallet this could waste cpu cycles. Normal staking happens every 15 seconds
+    // (see below) and results in fewer cpu cycles.
+    const int stakingInterval = std::max<int>(gArgs.GetArg("-staking", 15), 1);
+    const int64_t stakeSearchPeriodSeconds = params.PoSFutureBlockTimeLimit();
+    const int64_t endTime = GetAdjustedTime() + stakeSearchPeriodSeconds; // current time + seconds into future
+    // A closed staking window means we've exhausted the search for a new stake
+    const bool stakingWindowClosed = endTime <= lastUpdateTime + stakingInterval;
     const bool tipChanged = tip->nHeight != lastBlockHeight;
     const bool staleTip = tip->nTime <= lastUpdateTime || tip->nTime < GetAdjustedTime() - params.stakeMinAge*2; // TODO Blocknet testnet could stall chain?
-    if (notExpired && !tipChanged && staleTip)
-        return false; // do not process if not expired, tip hasn't changed, and tip time is stale
+    if (stakingWindowClosed && !tipChanged && staleTip)
+        return false; // do not process if staking window closed, tip hasn't changed, and tip time is stale
 
     {
         LOCK(mu);
@@ -65,7 +73,10 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
 
     std::vector<StakeOutput> selected; // selected coins that meet criteria for staking
     const int coinMaturity = params.coinMaturity;
-    const auto minStakeAmount = static_cast<CAmount>(gArgs.GetArg("-minstakeamount", 0) * COIN);
+    const auto argStakeAmount = static_cast<CAmount>(gArgs.GetArg("-minstakeamount", 0));
+    const auto minStakeAmount = argStakeAmount == 0 ? 1 : argStakeAmount * COIN;
+    const auto tipHeight = tip->nHeight;
+    const auto stakeHeight = tip->nHeight + 1;
 
     for (const auto & pwallet : wallets) {
         std::vector<COutput> coins; // all confirmed coins
@@ -79,24 +90,11 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
             pwallet->AvailableCoins(*locked_chain, coins, true, nullptr, minStakeAmount, MAX_MONEY, MAX_MONEY, 0);
         }
 
-        { // Remove all immature coins (any previous stakes that do not meet the maturity requirement)
-            LOCK(cs_main);
-            CCoinsViewCache &view = *pcoinsTip;
-            auto pred = [&view,&coinMaturity](const COutput & c) -> bool {
-                const auto & coin = view.AccessCoin(c.GetInputCoin().outpoint);
-                return coin.IsCoinBase() && coin.nHeight < coinMaturity;
-            };
-            coins.erase(std::remove_if(coins.begin(), coins.end(), pred), coins.end());
-        }
-
         // Find suitable staking coins
-        const int tipHeight = tip->nHeight;
         for (const COutput & out : coins) {
-            if (GetAdjustedTime() - out.tx->GetTxTime() < params.stakeMinAge) // skip coins that don't meet stake age
-                continue;
             if (out.tx->IsCoinBase()) // can't stake coinbase
                 continue;
-            if (out.nDepth < coinMaturity) // skip non-mature coins
+            if (out.tx->IsCoinStake() && out.nDepth < coinMaturity) // skip non-mature coinstakes
                 continue;
             if (!out.fSpendable) // skip coin we don't have keys for
                 continue;
@@ -108,47 +106,63 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
         }
     }
 
-    if (lastUpdateTime == 0) // Use chain tip last time on first call
-        lastUpdateTime = tip->nTime;
+    // Always search for stake from last block time if the tip changed
+    lastUpdateTime = tipChanged ? tip->GetBlockTime() + 1 : lastUpdateTime + 1;
 
-    int64_t currentTime = GetAdjustedTime(); // current time + seconds into future
-    int64_t endTime = currentTime + stakeSearchPeriodSeconds; // current time + seconds into future
     arith_uint256 bnTargetPerCoinDay;
     bnTargetPerCoinDay.SetCompact(tip->nBits);
 
     // Cache all possible stakes between last update and few seconds into the future
     for (const auto & item : selected) {
-        const auto out = item.out;
         boost::this_thread::interruption_point();
-        const auto & txInBlockHash = out->tx->hashBlock;
-        int hashBlockTime{0};
+        const auto out = item.out;
+        if (lastUpdateTime - out->tx->GetTxTime() < params.stakeMinAge) // skip coins that don't meet stake age
+            continue;
+
+        CBlockIndex *pindexStake = nullptr;
         {
             LOCK(cs_main);
-            const auto pindex = LookupBlockIndex(out->tx->hashBlock);
-            if (!pindex)
+            pindexStake = LookupBlockIndex(out->tx->hashBlock);
+            if (!pindexStake)
                 continue; // skip txs with block that can't be found
-            hashBlockTime = pindex->GetBlockTime();
         }
 
-        if (IsProtocolV05(lastUpdateTime)) { // if v05 staking protocol modifier is dynamic (not in hash lookup)
-            int64_t i = lastUpdateTime + 1;
+        const int hashBlockTime = pindexStake->GetBlockTime();
+        const auto & txInBlockHash = pindexStake->GetBlockHash();
+
+        if (IsProtocolV05(lastUpdateTime)) { // Protocol v5+
+            const auto estBlockTime = std::max(tip->GetBlockTime()+1, GetAdjustedTime());
+            if (estBlockTime - params.stakeMinAge <= hashBlockTime) // valid modifier time check
+                continue;
+
+            int64_t i = lastUpdateTime;
             for (; i < endTime; ++i) {
+                if (i - out->tx->GetTxTime() < params.stakeMinAge)
+                    continue; // skip coins that don't meet stake age
                 uint64_t stakeModifier{0};
                 int stakeModifierHeight{0};
                 int64_t stakeModifierTime{0};
-                if (!GetKernelStakeModifier(tip, txInBlockHash, static_cast<const unsigned int>(i), stakeModifier, stakeModifierHeight, stakeModifierTime, false))
+                if (!GetKernelStakeModifier(tip, pindexStake, estBlockTime, stakeModifier, stakeModifierHeight, stakeModifierTime))
                     continue;
 
                 CDataStream ss(SER_GETHASH, 0);
                 ss << stakeModifier;
 
-                const auto hashProofOfStake = stakeHashV05(ss, hashBlockTime, tip->nHeight + 1, out->i, i);
-                if (!stakeTargetHit(hashProofOfStake, out->GetInputCoin().txout.nValue, bnTargetPerCoinDay))
-                    continue;
+                uint256 hashProofOfStake;
+                if (IsProtocolV06(estBlockTime, params)) {
+                    hashProofOfStake = stakeHashV06(ss, txInBlockHash, hashBlockTime, stakeHeight, out->i, i);
+                    if (!stakeTargetHitV06(hashProofOfStake, out->GetInputCoin().txout.nValue, bnTargetPerCoinDay))
+                        continue;
+                } else {
+                    hashProofOfStake = stakeHashV05(ss, hashBlockTime, stakeHeight, out->i, i);
+                    if (!stakeTargetHit(hashProofOfStake, out->GetInputCoin().txout.nValue, bnTargetPerCoinDay))
+                        continue;
+                }
+
                 {
                     LOCK(mu);
                     stakeTimes[i].emplace_back(std::make_shared<CInputCoin>(out->GetInputCoin()), item.wallet, i,
-                                               out->tx->hashBlock, hashBlockTime, hashProofOfStake);
+                            estBlockTime, txInBlockHash, hashBlockTime, hashProofOfStake);
                     break;
                 }
             }
@@ -157,7 +171,7 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
             int stakeModifierHeight{0};
             int64_t stakeModifierTime{0};
             const unsigned int stakeTime{0}; // this is not used here by v03 staking protocol (see GetKernelStakeModifierV03)
-            if (stakeModifier == 0 && !GetKernelStakeModifier(tip, txInBlockHash, stakeTime, stakeModifier, stakeModifierHeight, stakeModifierTime, false))
+            if (stakeModifier == 0 && !GetKernelStakeModifier(tip, pindexStake, stakeTime, stakeModifier, stakeModifierHeight, stakeModifierTime))
                 continue;
 
             if (!HasStakeModifier(txInBlockHash)) {
@@ -167,14 +181,16 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
             CDataStream ss(SER_GETHASH, 0);
             ss << stakeModifier;
 
-            int64_t i = lastUpdateTime + 1;
+            int64_t i = lastUpdateTime;
             for (; i < endTime; ++i) {
+                if (i - out->tx->GetTxTime() < params.stakeMinAge) // skip coins that don't meet stake age
+                    continue;
                 const auto hashProofOfStake = stakeHash(i, ss, out->i, out->tx->GetHash(), hashBlockTime);
                 if (!stakeTargetHit(hashProofOfStake, out->GetInputCoin().txout.nValue, bnTargetPerCoinDay))
                     continue;
                 {
                     LOCK(mu);
-                    stakeTimes[i].emplace_back(std::make_shared<CInputCoin>(out->GetInputCoin()), item.wallet, i,
+                    stakeTimes[i].emplace_back(std::make_shared<CInputCoin>(out->GetInputCoin()), item.wallet, i, 0,
                                                out->tx->hashBlock, hashBlockTime, hashProofOfStake);
                     break;
                 }
@@ -183,7 +199,7 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
 
     }
 
-    lastBlockHeight = tip->nHeight;
+    lastBlockHeight = tipHeight;
     lastUpdateTime = endTime;
     LogPrint(BCLog::ALL, "Staker: %u\n", lastBlockHeight);
     return !stakeTimes.empty();
@@ -210,7 +226,7 @@ bool StakeMgr::NextStake(std::vector<StakeCoin> & nextStakes, const CBlockIndex 
     if (stakeTimes.empty())
         return false;
 
-    const auto cutoffTime = tip->nTime; // must find stake input valid for a time newer than cutoff
+    const auto cutoffTime = tip->GetBlockTime(); // must find stake input valid for a time newer than cutoff
     arith_uint256 bnTargetPerCoinDay; // current difficulty
     bnTargetPerCoinDay.SetCompact(tip->nBits);
 
@@ -229,7 +245,10 @@ bool StakeMgr::NextStake(std::vector<StakeCoin> & nextStakes, const CBlockIndex 
         // Find the smallest stake input that meets the protocol requirements
         for (const auto & stake : stakes) {
             // Make sure stake still meets network requirements
-            if (!stakeTargetHit(stake.hashProofOfStake, stake.coin->txout.nValue, bnTargetPerCoinDay))
+            if (IsProtocolV06(stake.blockTime, chainparams.GetConsensus())) {
+                if (!stakeTargetHitV06(stake.hashProofOfStake, stake.coin->txout.nValue, bnTargetPerCoinDay))
+                    continue;
+            } else if (!stakeTargetHit(stake.hashProofOfStake, stake.coin->txout.nValue, bnTargetPerCoinDay))
                 continue;
             nextStakes.push_back(stake);
         }
@@ -250,7 +269,8 @@ bool StakeMgr::StakeBlock(const StakeCoin & stakeCoin, const CChainParams & chai
     bool fNewBlock = false;
     try {
         auto pblocktemplate = BlockAssembler(chainparams).CreateNewBlockPoS(*stakeCoin.coin, stakeCoin.hashBlock,
-                                                                            stakeCoin.time, stakeCoin.wallet.get());
+                                                                            stakeCoin.time, stakeCoin.blockTime,
+                                                                            stakeCoin.wallet.get());
         if (!pblocktemplate)
             return false;
         auto pblock = std::make_shared<const CBlock>(pblocktemplate->block);

--- a/src/stakemgr.h
+++ b/src/stakemgr.h
@@ -21,15 +21,16 @@ public:
         std::shared_ptr<CInputCoin> coin;
         std::shared_ptr<CWallet> wallet;
         int64_t time;
+        int64_t blockTime;
         uint256 hashBlock;
         int64_t hashBlockTime;
         uint256 hashProofOfStake;
         explicit StakeCoin() {
             SetNull();
         }
-        explicit StakeCoin(std::shared_ptr<CInputCoin> coin, std::shared_ptr<CWallet> wallet, int64_t time,
+        explicit StakeCoin(std::shared_ptr<CInputCoin> coin, std::shared_ptr<CWallet> wallet, int64_t time, int64_t blockTime,
                            uint256 hashBlock, int64_t hashBlockTime, uint256 hashProofOfStake)
-                                          : coin(coin), wallet(wallet), time(time),
+                                          : coin(coin), wallet(wallet), time(time), blockTime(blockTime),
                                             hashBlock(hashBlock), hashBlockTime(hashBlockTime),
                                             hashProofOfStake(hashProofOfStake) { }
         bool IsNull() {
@@ -39,6 +40,7 @@ public:
             coin = nullptr;
             wallet = nullptr;
             time = 0;
+            blockTime = 0;
             hashBlock.SetNull();
             hashBlockTime = 0;
             hashProofOfStake.SetNull();

--- a/src/stakemgr.h
+++ b/src/stakemgr.h
@@ -64,6 +64,11 @@ public:
     int64_t LastUpdateTime() const;
     int LastBlockHeight() const;
     const StakeCoin & GetStake();
+    bool SuitableCoin(const COutput & coin, const int & tipHeight, const Consensus::Params & params) const;
+    std::vector<COutput> StakeOutputs(CWallet *wallet, const CAmount & minStakeAmount) const;
+    bool GetStakesMeetingTarget(const std::shared_ptr<COutput> & coin, std::shared_ptr<CWallet> & wallet,
+        const CBlockIndex *tip, const int64_t & adjustedTime, const int64_t & blockTime, const int64_t & fromTime,
+        const int64_t & toTime, std::map<int64_t, std::vector<StakeCoin>> & stakes, const Consensus::Params & params);
 
 private:
     bool HasStakeModifier(const uint256 & blockHash) {
@@ -73,6 +78,10 @@ private:
     uint64_t GetStakeModifier(const uint256 & blockHash) {
         LOCK(mu);
         return stakeModifiers.count(blockHash) ? stakeModifiers[blockHash] : 0;
+    }
+    void UpdateStakeModifier(const uint256 & blockHash, const uint64_t & stakeModifier) {
+        LOCK(mu);
+        stakeModifiers[blockHash] = stakeModifier;
     }
 
 private:

--- a/src/test/servicenode_tests.cpp
+++ b/src/test/servicenode_tests.cpp
@@ -37,30 +37,34 @@ void cleanupSn() {
     mempool.clear();
 }
 
+bool ServiceNodeSetupFixtureSetup{false};
 struct ServiceNodeSetupFixture {
     explicit ServiceNodeSetupFixture() {
+        if (ServiceNodeSetupFixtureSetup) return; ServiceNodeSetupFixtureSetup = true;
         chain_1000_50();
         chain_1250_50();
     }
     void chain_1000_50() {
-        TestChainPoS pos(false);
+        auto pos = std::make_shared<TestChainPoS>(false);
         auto *params = (CChainParams*)&Params();
         params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
             if (blockHeight <= consensusParams.lastPOWBlock)
                 return 1000 * COIN;
             return 50 * COIN;
         };
-        pos.Init("1000,50");
+        pos->Init("1000,50");
+        pos.reset();
     }
     void chain_1250_50() {
-        TestChainPoS pos(false);
+        auto pos = std::make_shared<TestChainPoS>(false);
         auto *params = (CChainParams*)&Params();
         params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
             if (blockHeight <= consensusParams.lastPOWBlock)
                 return 1250 * COIN;
             return 50 * COIN;
         };
-        pos.Init("1250,50");
+        pos->Init("1250,50");
+        pos.reset();
     }
 };
 
@@ -69,7 +73,8 @@ BOOST_FIXTURE_TEST_SUITE(servicenode_tests, ServiceNodeSetupFixture)
 /// Check case where servicenode is properly validated under normal circumstances
 BOOST_AUTO_TEST_CASE(servicenode_tests_isvalid)
 {
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -104,6 +109,7 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_isvalid)
     BOOST_CHECK(snode.isValid(GetTxFunc, IsServiceNodeBlockValidFunc));
 
     cleanupSn();
+    pos_ptr.reset();
 }
 
 /// Check open tier case
@@ -199,7 +205,8 @@ BOOST_FIXTURE_TEST_CASE(servicenode_tests_insufficient_collateral, TestChainPoS)
 /// Check case where collateral inputs are spent
 BOOST_AUTO_TEST_CASE(servicenode_tests_spent_collateral)
 {
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -372,13 +379,15 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_spent_collateral)
 
         cleanupSn();
     }
+    pos_ptr.reset();
 }
 
 /// Check case where servicenode is re-registered on spent collateral
 BOOST_AUTO_TEST_CASE(servicenode_tests_reregister_onspend)
 {
     gArgs.SoftSetBoolArg("-servicenode", true);
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -484,12 +493,14 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_reregister_onspend)
     UnregisterValidationInterface(&sn::ServiceNodeMgr::instance());
     gArgs.SoftSetBoolArg("-servicenode", false);
     cleanupSn();
+    pos_ptr.reset();
 }
 
 /// Check case where collateral inputs are immature
 BOOST_AUTO_TEST_CASE(servicenode_tests_immature_collateral)
 {
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -606,13 +617,15 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_immature_collateral)
     RemoveWallet(otherwallet);
     cleanupSn();
     gArgs.SoftSetBoolArg("-servicenode", false);
+    pos_ptr.reset();
 }
 
 /// Servicenode registration and ping tests
 BOOST_AUTO_TEST_CASE(servicenode_tests_registration_pings)
 {
     gArgs.SoftSetBoolArg("-servicenode", true);
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -761,12 +774,14 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_registration_pings)
 
     gArgs.SoftSetBoolArg("-servicenode", false);
     cleanupSn();
+    pos_ptr.reset();
 }
 
 /// Check misc cases
 BOOST_AUTO_TEST_CASE(servicenode_tests_misc_checks)
 {
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -1021,13 +1036,15 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_misc_checks)
     }
 
     cleanupSn();
+    pos_ptr.reset();
 }
 
 /// Check rpc cases
 BOOST_AUTO_TEST_CASE(servicenode_tests_rpc)
 {
     gArgs.SoftSetBoolArg("-servicenode", true);
-    TestChainPoS pos(false);
+    auto pos_ptr = std::make_shared<TestChainPoS>(false);
+    auto & pos = *pos_ptr;
     auto *params = (CChainParams*)&Params();
     params->consensus.GetBlockSubsidy = [](const int & blockHeight, const Consensus::Params & consensusParams) {
         if (blockHeight <= consensusParams.lastPOWBlock)
@@ -1491,6 +1508,7 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_rpc)
 
     gArgs.SoftSetBoolArg("-servicenode", false);
     cleanupSn();
+    pos_ptr.reset();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/staking_tests.h
+++ b/src/test/staking_tests.h
@@ -114,7 +114,7 @@ struct TestChainPoS : public TestingSetup {
         keystore.AddKey(coinbaseKey);
         CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
         for (int i = 0; i < Params().GetConsensus().lastPOWBlock; ++i) {
-            SetMockTime(GetAdjustedTime() + Params().GetConsensus().nPowTargetSpacing); // prevent difficulty from increasing too rapidly
+            SetMockTime(GetAdjustedTime() + Params().GetConsensus().nPowTargetSpacing);
             std::vector<CMutableTransaction> txs;
             if (i > Params().GetConsensus().coinMaturity) {
                 int j = i - Params().GetConsensus().coinMaturity;
@@ -262,10 +262,15 @@ struct TestChainPoS : public TestingSetup {
     }
 
     ~TestChainPoS() {
-        UnregisterValidationInterface(wallet.get());
-        RemoveWallet(wallet);
-        g_txindex->Stop();
-        g_txindex.reset();
+        if (g_txindex) {
+            g_txindex->Stop();
+            g_txindex.reset();
+        }
+        if (wallet) {
+            UnregisterValidationInterface(wallet.get());
+            RemoveWallet(wallet);
+            wallet.reset();
+        }
     };
 
     std::unique_ptr<interfaces::Chain> chain = interfaces::MakeChain();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -20,7 +20,9 @@
 
 // from kernel.h
 bool IsProofOfStake(int blockHeight, const Consensus::Params & consensusParams);
-bool stakeTargetHit(uint256 hashProofOfStake, int64_t nValueIn, arith_uint256 bnTargetPerCoinDay);
+bool stakeTargetHit(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
+bool IsProtocolV06(uint64_t nTimeTx, const Consensus::Params & consensusParams);
+bool stakeTargetHitV06(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
 
 static const char DB_COIN = 'C';
 static const char DB_COINS = 'c';
@@ -305,7 +307,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
                 if (IsProofOfStake(diskindex->nHeight, consensusParams)) { // Blocknet PoS check work
                     arith_uint256 bnTargetPerCoinDay; bnTargetPerCoinDay.SetCompact(diskindex->nBits);
-                    if (!stakeTargetHit(diskindex->hashProofOfStake, diskindex->nStakeAmount, bnTargetPerCoinDay))
+                    if (IsProtocolV06(diskindex->GetBlockTime(), consensusParams)) {
+                        if (!stakeTargetHitV06(diskindex->hashProofOfStake, diskindex->nStakeAmount, bnTargetPerCoinDay))
+                            continue;
+                    } else if (!stakeTargetHit(diskindex->hashProofOfStake, diskindex->nStakeAmount, bnTargetPerCoinDay))
                         continue;
                 } else if (!IsProofOfStake(diskindex->nHeight, consensusParams) && !CheckProofOfWork(hash, diskindex->nBits, consensusParams))
                     continue;


### PR DESCRIPTION
- Leverages block `nNonce` instead of `nTime`
- Include block hash of staking input in the PoS hash
- Difficulty based on block time (not variable stake time)
- Protocol enforces nonce as valid stake time (if nonce doesn't solve the target block is rejected)
- Decreased stake weight by 2x
- Introduces `staking=number_of_seconds` to indicate how aggressively you want the staker to search. Default is 15 seconds (4 times per minute) or immediately after every new block (search always happens immediately after new block regardless of number specified). For Rasp pi's you can set to 60 (once per minute) to significantly reduce cpu cycles when many coin inputs are present.