### PR TITLE
Improve servicenodecreateinputs rpc call

### DIFF
--- a/src/test/servicenode_tests.cpp
+++ b/src/test/servicenode_tests.cpp
@@ -1393,8 +1393,8 @@ BOOST_AUTO_TEST_CASE(servicenode_tests_rpc)
                                     false};
             vecSend.push_back(recipient);
         }
-        // For fee
-        vecSend.push_back({GetScriptForDestination(dest), COIN, false});
+        vecSend.push_back({GetScriptForDestination(dest), COIN, false}); // For voting input
+        vecSend.push_back({GetScriptForDestination(dest), COIN, false}); // For fee
         CCoinControl cc;
         CTransactionRef tx;
         {


### PR DESCRIPTION
- Now creates a `1 BLOCK` default voting input used to cast votes
- Change goes to the snode address 