### PR TITLE
Fix block index init

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -452,6 +452,7 @@ class CDiskBlockIndex : public CBlockIndex
 {
 public:
     uint256 hashPrev;
+    uint256 hash;
 
     CDiskBlockIndex() {
         hashPrev = uint256();
@@ -512,6 +513,10 @@ public:
         return block.GetHash();
     }
 
+    uint256 CacheBlockHash() {
+        hash = GetBlockHash();
+        return hash;
+    }
 
     std::string ToString() const
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -424,6 +424,7 @@ void SetupServerArgs()
     hidden_args.emplace_back("-sysperms");
 #endif
     gArgs.AddArg("-txindex", "Blocknet requires txindex to support the Proof of Stake protocol.", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-lowmemoryload", "Use less memory during initial load. This may result in longer load times, however, may improve loading on memory constrained devices if out of memory errors persist (e.g. Rasp Pi)", false, OptionsCategory::OPTIONS);
 
     gArgs.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). This option can be specified multiple times to add multiple nodes.", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-banscore=<n>", strprintf("Threshold for disconnecting misbehaving peers (default: %u)", DEFAULT_BANSCORE_THRESHOLD), false, OptionsCategory::CONNECTION);
@@ -1516,9 +1517,9 @@ bool AppInitMain(InitInterfaces& interfaces)
     int64_t nTotalCache = (gArgs.GetArg("-dbcache", nDefaultDbCache) << 20);
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
-    int64_t nBlockTreeDBCache = std::min(nTotalCache / 8, nMaxBlockDBCache << 20);
+    int64_t nBlockTreeDBCache = std::min(nTotalCache / 6, nMaxBlockDBCache << 20);
     nTotalCache -= nBlockTreeDBCache;
-    int64_t nTxIndexCache = std::min(nTotalCache / 8, nMaxTxIndexCache << 20); // Blocknet PoS requires txindex
+    int64_t nTxIndexCache = std::min(nTotalCache / 2, nMaxTxIndexCache << 20); // Blocknet PoS requires txindex
     nTotalCache -= nTxIndexCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -517,6 +517,11 @@ void OptionsModel::checkAndMigrate()
         if (settingsVersion < 130000 && settings.contains("nDatabaseCache") && settings.value("nDatabaseCache").toLongLong() == 100)
             settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
 
+        // Blocknet -dbcache was bumped from 450 to 550 in 4.1
+        // force people to upgrade to the new value if they are using 450MB
+        if (settingsVersion < 4010000 && settings.contains("nDatabaseCache") && settings.value("nDatabaseCache").toLongLong() == 450)
+            settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
+
         settings.setValue(strSettingsVersionKey, CLIENT_VERSION);
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -271,15 +271,20 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
     std::atomic<int> counter{0};
     std::atomic<double> pcounter{0};
-    const int totalprogress{90};
-    auto progress = [&counter,&pcounter,totalprogress](const double & unit, const double & total, const double & percent) {
+    std::atomic<int> pprog{0};
+    const int totalprogress{85};
+    auto progress = [&counter,&pcounter,&pprog,totalprogress](const double & unit, const double & total, const double & percent) {
         ++counter;
         pcounter = pcounter + unit/total * percent;
         if (counter % 10000 == 0) {
             int p = static_cast<int>(pcounter);
             if (p >= totalprogress) p = totalprogress;
-            LogPrintf("[%u%%]...", p); /* Continued */
-            uiInterface.ShowProgress("Loading block index", p, false);
+            if (p != pprog) {
+                pprog = p;
+                if (pprog % 10 == 0)
+                    LogPrintf("[%u%%]...", pprog); /* Continued */
+                uiInterface.ShowProgress("Loading block index", pprog, false);
+            }
         }
     };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -267,12 +267,13 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
     LogPrintf("[0%%]..."); /* Continued */
     uiInterface.ShowProgress("Loading block index", 0, false);
 
-    const int group{100000}; // shard count
+    const int group{50000}; // shard count
+    const int estTotalBlocks = static_cast<int>((double)consensusParams.lastCheckpointHeight * 1.15);
 
     std::atomic<int> counter{0};
     std::atomic<double> pcounter{0};
     std::atomic<int> pprog{0};
-    const int totalprogress{85};
+    const int totalprogress{70};
     auto progress = [&counter,&pcounter,&pprog,totalprogress](const double & unit, const double & total, const double & percent) {
         ++counter;
         pcounter = pcounter + unit/total * percent;
@@ -288,45 +289,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
         }
     };
 
-    auto loadIndices = [&insertBlockIndex,&progress,consensusParams](const std::vector<CDiskBlockIndex> & blocks, const std::unordered_set<uint256, TXDBHasher> & invalidBlocks) {
-        // Construct block index objects
-        for (const auto & diskindex : blocks) {
-            const auto & hash = diskindex.GetBlockHash();
-            if (invalidBlocks.count(hash) > 0)
-                continue;
-            CBlockIndex *pindexNew      = insertBlockIndex(hash);
-            pindexNew->pprev            = insertBlockIndex(diskindex.hashPrev);
-            pindexNew->nHeight          = diskindex.nHeight;
-            pindexNew->nFile            = diskindex.nFile;
-            pindexNew->nDataPos         = diskindex.nDataPos;
-            pindexNew->nUndoPos         = diskindex.nUndoPos;
-            pindexNew->nVersion         = diskindex.nVersion;
-            pindexNew->hashMerkleRoot   = diskindex.hashMerkleRoot;
-            pindexNew->nTime            = diskindex.nTime;
-            pindexNew->nBits            = diskindex.nBits;
-            pindexNew->nNonce           = diskindex.nNonce;
-            pindexNew->nStatus          = diskindex.nStatus;
-            pindexNew->nTx              = diskindex.nTx;
-            // ppcoin: PoS
-            pindexNew->nMint            = diskindex.nMint;
-            pindexNew->nMoneySupply     = diskindex.nMoneySupply;
-            pindexNew->nFlags           = diskindex.nFlags;
-            pindexNew->nStakeModifier   = diskindex.nStakeModifier;
-            pindexNew->prevoutStake     = diskindex.prevoutStake;
-            pindexNew->nStakeAmount     = diskindex.nStakeAmount;
-            pindexNew->hashStakeBlock   = diskindex.hashStakeBlock;
-            pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
-
-            progress(1, consensusParams.lastCheckpointHeight*1.15, 45);
-        }
-    };
-
-    auto checkWork = [group,&insertBlockIndex,&progress,consensusParams,this](const std::vector<CDiskBlockIndex> & blocks,
-            std::unordered_set<uint256, TXDBHasher> & invalidBlocks)
+    auto checkWork = [&insertBlockIndex,&progress,totalprogress,estTotalBlocks,consensusParams,this](
+            std::vector<CDiskBlockIndex> & blocks, std::unordered_set<uint256, TXDBHasher> & invalidBlocks)
     {
         boost::thread_group tg;
         Mutex mu;
-        const int slice = std::min<int>(blocks.size(), group);
+        const int slice = blocks.size();
         const int cores = GetNumCores();
         const int shard = slice/cores;
         for (int i = 0; i < cores; ++i) {
@@ -335,36 +303,32 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
             if (to > blocks.size())
                 to = blocks.size();
 
-            tg.create_thread([from,to,&blocks,&invalidBlocks,&insertBlockIndex,&mu,&progress,group,consensusParams,this] {
+            tg.create_thread([from,to,&blocks,&invalidBlocks,&insertBlockIndex,&mu,&progress,totalprogress,estTotalBlocks,consensusParams,this] {
                 RenameThread("blocknet-blockindex");
-
-                // Blocknet PoS check work
+                // Construct block index objects
                 for (int j = from; j < to; ++j) {
-                    if (ShutdownRequested())
-                        break;
-                    const auto & diskindex = blocks[j];
-                    const auto & hash = diskindex.GetBlockHash();
-
-                    if (IsProofOfStake(diskindex.nHeight, consensusParams)) {
-                        arith_uint256 bnTargetPerCoinDay; bnTargetPerCoinDay.SetCompact(diskindex.nBits);
-                        if (IsProtocolV06(diskindex.GetBlockTime(), consensusParams)) {
-                            if (!stakeTargetHitV06(diskindex.hashProofOfStake, diskindex.nStakeAmount, bnTargetPerCoinDay)) {
+                    auto *diskindex = &blocks[j];
+                    const auto & hash = diskindex->CacheBlockHash();
+                    if (IsProofOfStake(diskindex->nHeight, consensusParams)) {
+                        arith_uint256 bnTargetPerCoinDay; bnTargetPerCoinDay.SetCompact(diskindex->nBits);
+                        if (IsProtocolV06(diskindex->GetBlockTime(), consensusParams)) {
+                            if (!stakeTargetHitV06(diskindex->hashProofOfStake, diskindex->nStakeAmount, bnTargetPerCoinDay)) {
                                 LOCK(mu);
                                 invalidBlocks.insert(hash);
                                 continue;
                             }
-                        } else if (!stakeTargetHit(diskindex.hashProofOfStake, diskindex.nStakeAmount, bnTargetPerCoinDay)) {
+                        } else if (!stakeTargetHit(diskindex->hashProofOfStake, diskindex->nStakeAmount, bnTargetPerCoinDay)) {
                             LOCK(mu);
                             invalidBlocks.insert(hash);
                             continue;
                         }
-                    } else if (!IsProofOfStake(diskindex.nHeight, consensusParams) && !CheckProofOfWork(hash, diskindex.nBits, consensusParams)) {
+                    } else if (!IsProofOfStake(diskindex->nHeight, consensusParams) && !CheckProofOfWork(hash, diskindex->nBits, consensusParams)) {
                         LOCK(mu);
                         invalidBlocks.insert(hash);
                         continue;
                     }
 
-                    progress(1, consensusParams.lastCheckpointHeight*1.15, 45);
+                    progress(1, estTotalBlocks, 30);
                 }
             });
         }
@@ -372,22 +336,62 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
         tg.join_all();
     };
 
+    auto loadIndices = [&insertBlockIndex,&progress,estTotalBlocks](const std::vector<CDiskBlockIndex> & blocks, std::unordered_set<uint256, TXDBHasher> & invalidBlocks) {
+        // Construct block index objects
+        for (const auto & diskindex : blocks) {
+            const auto & hash = diskindex.hash;
+            if (invalidBlocks.count(hash))
+                continue;
+
+            CBlockIndex *pindexNew = insertBlockIndex(hash);
+            pindexNew->pprev = insertBlockIndex(diskindex.hashPrev);
+            pindexNew->nHeight = diskindex.nHeight;
+            pindexNew->nFile = diskindex.nFile;
+            pindexNew->nDataPos = diskindex.nDataPos;
+            pindexNew->nUndoPos = diskindex.nUndoPos;
+            pindexNew->nVersion = diskindex.nVersion;
+            pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
+            pindexNew->nTime = diskindex.nTime;
+            pindexNew->nBits = diskindex.nBits;
+            pindexNew->nNonce = diskindex.nNonce;
+            pindexNew->nStatus = diskindex.nStatus;
+            pindexNew->nTx = diskindex.nTx;
+            // ppcoin: PoS
+            pindexNew->nMint = diskindex.nMint;
+            pindexNew->nMoneySupply = diskindex.nMoneySupply;
+            pindexNew->nFlags = diskindex.nFlags;
+            pindexNew->nStakeModifier = diskindex.nStakeModifier;
+            pindexNew->prevoutStake = diskindex.prevoutStake;
+            pindexNew->nStakeAmount = diskindex.nStakeAmount;
+            pindexNew->hashStakeBlock = diskindex.hashStakeBlock;
+            pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
+
+            progress(1, estTotalBlocks, 15);
+        }
+    };
+
+    const auto lowMemory = gArgs.GetBoolArg("-lowmemoryload", false);
     std::vector<CDiskBlockIndex> blocks;
+    blocks.reserve(lowMemory ? std::min<int>(group, consensusParams.lastCheckpointHeight) : consensusParams.lastCheckpointHeight);
 
     // Load mapBlockIndex
     while (pcursor->Valid()) {
-        boost::this_thread::interruption_point();
         std::pair<char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {
             CDiskBlockIndex diskindex;
             if (pcursor->GetValue(diskindex)) {
                 blocks.push_back(diskindex);
                 if (blocks.size() % group == 0) {
-                    std::unordered_set<uint256, TXDBHasher> invalidBlocks;
-                    checkWork(blocks, invalidBlocks);
-                    loadIndices(blocks, invalidBlocks);
-                    blocks.clear();
+                    boost::this_thread::interruption_point();
+                    if (lowMemory) {
+                        std::unordered_set<uint256, TXDBHasher> invalidBlocks;
+                        checkWork(blocks, invalidBlocks);
+                        loadIndices(blocks, invalidBlocks);
+                        blocks.clear();
+                        blocks.reserve(std::min<int>(group, consensusParams.lastCheckpointHeight));
+                    }
                 }
+                progress(1, estTotalBlocks, 25);
                 pcursor->Next();
             } else {
                 return error("%s: failed to read value", __func__);
@@ -403,6 +407,12 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
         checkWork(blocks, invalidBlocks);
         loadIndices(blocks, invalidBlocks);
         blocks.clear();
+    }
+
+    // Indicate total progress for this section is complete
+    if (pprog != totalprogress) {
+        LogPrintf("[%u%%]...", totalprogress); /* Continued */
+        uiInterface.ShowProgress("Loading block index", totalprogress, false);
     }
 
     return true;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -24,7 +24,7 @@ class uint256;
 //! No need to periodic flush if at least this much space still available.
 static constexpr int MAX_BLOCK_COINSDB_USAGE = 10;
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 450;
+static const int64_t nDefaultDbCache = 550;
 //! -dbbatchsize default (bytes)
 static const int64_t nDefaultDbBatchSize = 16 << 20;
 //! max. -dbcache (MiB)
@@ -32,13 +32,13 @@ static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache (MiB)
 static const int64_t nMinDbCache = 4;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
-static const int64_t nMaxBlockDBCache = 2;
+static const int64_t nMaxBlockDBCache = 16;
 //! Max memory allocated to block tree DB specific cache, if -txindex (MiB)
 // Unlike for the UTXO database, for the txindex scenario the leveldb cache make
 // a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
-static const int64_t nMaxTxIndexCache = 1024;
+static const int64_t nMaxTxIndexCache = 3096;
 //! Max memory allocated to coin DB specific cache (MiB)
-static const int64_t nMaxCoinsDBCache = 8;
+static const int64_t nMaxCoinsDBCache = 32;
 
 /** CCoinsView backed by the coin database (chainstate/) */
 class CCoinsViewDB final : public CCoinsView

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3987,8 +3987,8 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
         return false;
 
     std::atomic<int> counter{0};
-    std::atomic<double> pcounter{85};
-    std::atomic<int> pprog{0};
+    std::atomic<double> pcounter{70};
+    std::atomic<int> pprog{70};
     const int totalprogress{100};
     auto progress = [&counter,&pcounter,&pprog,totalprogress](const double & unit, const double & total, const double & percent) {
         ++counter;
@@ -4013,7 +4013,7 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
     {
         CBlockIndex* pindex = item.second;
         vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
-        progress(1, mbiCount, 3); // total progress in LoadBlockIndex must be <= 10
+        progress(1, mbiCount, 10); // total progress in LoadBlockIndex must be <= 30
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
     for (const std::pair<int, CBlockIndex*>& item : vSortedByHeight)
@@ -4052,7 +4052,7 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
         if (!IsProtocolV05(pindex->GetBlockTime()))
             mapHeaderIndex[pindex->nHeight] = pindex;
 
-        progress(1, mbiCount, 7); // total progress in LoadBlockIndex must be <= 10
+        progress(1, mbiCount, 20); // total progress in LoadBlockIndex must be <= 30
     }
 
     LogPrintf("[DONE].\n");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3987,16 +3987,21 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
         return false;
 
     std::atomic<int> counter{0};
-    std::atomic<double> pcounter{90};
+    std::atomic<double> pcounter{85};
+    std::atomic<int> pprog{0};
     const int totalprogress{100};
-    auto progress = [&counter,&pcounter,totalprogress](const double & unit, const double & total, const double & percent) {
+    auto progress = [&counter,&pcounter,&pprog,totalprogress](const double & unit, const double & total, const double & percent) {
         ++counter;
         pcounter = pcounter + unit/total * percent;
         if (counter % 100000 == 0) {
             int p = static_cast<int>(pcounter);
             if (p >= totalprogress) p = totalprogress;
-            LogPrintf("[%u%%]...", p); /* Continued */
-            uiInterface.ShowProgress("Loading block index", p, false);
+            if (p != pprog) {
+                pprog = p;
+                if (pprog % 10 == 0)
+                    LogPrintf("[%u%%]...", pprog); /* Continued */
+                uiInterface.ShowProgress("Loading block index", pprog, false);
+            }
         }
     };
 


### PR DESCRIPTION
Improve how the block index is loaded on program start.

- Concurrent implementation of loading the block index
- Can set `fastload=0` to turn off for low-memory devices like Rasp PI
- Log the index load every 10% to reduce log spam