### PR TITLE
[gov] add proposal status to listproposals rpc

### DIFF
--- a/src/qt/blocknetproposals.cpp
+++ b/src/qt/blocknetproposals.cpp
@@ -271,7 +271,11 @@ void BlocknetProposals::initialize() {
         if (it != sbResults.end())
             tally = it->second;
 
-        if (currentBlock < proposal.getSuperblock() && tally.payout) {
+        if (nextSuperblock < proposal.getSuperblock()) {
+            results = tr("Pending");
+            statusColor = STATUS_IN_PROGRESS;
+        }
+        else if (currentBlock < proposal.getSuperblock() && tally.payout) {
             results = tr("Passing");
             statusColor = STATUS_PASSED;
         }


### PR DESCRIPTION
Adds `status` to the listproposals rpc call indicating whether the proposal is passing or failing.