### PR TITLE
Fix coinstake fees

### DIFF
--- a/src/governance/governancewallet.cpp
+++ b/src/governance/governancewallet.cpp
@@ -646,6 +646,8 @@ bool RevoteOnStake(const int & stakedHeight, const COutPoint & utxo, const CKey 
 
     CMutableTransaction votetx;
     CCoinControl cc;
+    if (IsNetworkFeesEnabled(chainActive.Tip(), params))
+        cc.m_zero_fee = true;
     cc.fAllowOtherInputs = false;
     cc.destChange = CTxDestination(key.GetPubKey().GetID()); // pay change to address of staking utxo
     // Select first voting input

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -19,5 +19,6 @@ void CCoinControl::SetNull()
     m_confirm_target.reset();
     m_signal_bip125_rbf.reset();
     m_fee_mode = FeeEstimateMode::UNSET;
+    m_zero_fee = false;
 }
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -38,6 +38,8 @@ public:
     bool m_avoid_partial_spends;
     //! Fee estimation mode to control arguments to estimateSmartFee
     FeeEstimateMode m_fee_mode;
+    //! 0-fee
+    bool m_zero_fee;
 
     CCoinControl()
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3158,6 +3158,9 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     return false;
                 }
 
+                if (coin_control.m_zero_fee)
+                    break; // support 0 fee txs (useful in vote txs)
+                else {
                 nFeeNeeded = GetMinimumFee(*this, nBytes, coin_control, ::mempool, ::feeEstimator, &feeCalc);
                 if (feeCalc.reason == FeeReason::FALLBACK && !m_allow_fallback_fee) {
                     // eventually allow a fallback fee
@@ -3244,6 +3247,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                 nFeeRet = nFeeNeeded;
                 coin_selection_params.use_bnb = false;
                 continue;
+                } // coin_control.m_zero_fee
             }
         }
 


### PR DESCRIPTION
Fees are no longer consumed on coinstake's while the network fee payment spork is active.