### PR TITLE
[core] Add -staketoaddress option

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -349,6 +349,18 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlockPoS(const CInputCo
         CAmount estimatedNetworkFee = static_cast<CAmount>(::minRelayTxFee.GetFee(coinbaseBytes) + ::minRelayTxFee.GetFee(coinstakeBytes));
         coinstakeTx.vout[1] = CTxOut(stakeInput.txout.nValue + stakeAmount - estimatedNetworkFee, paymentScript); // staker payment w/ network fee taken out
     }
+
+    // Stake to address feature
+    const auto stakeToAddress = gArgs.GetArg("-staketoaddress", "");
+    const auto stakeToAddressEnabled = !stakeToAddress.empty() && !gov::Governance::isSuperblock(nHeight, chainparams.GetConsensus()) && IsValidDestinationString(stakeToAddress);
+    if (stakeToAddressEnabled) {
+        auto stakeToAddressDest = DecodeDestination(stakeToAddress);
+        CKey stakeToAddressKey;
+        if (keystore->GetKey(GetKeyForDestination(*keystore, stakeToAddressDest), stakeToAddressKey)) {
+            coinstakeTx.vout[1] = CTxOut(coinstakeTx.vout[1].nValue - stakeAmount, paymentScript); // remove stake amount
+            coinstakeTx.vout.emplace_back(stakeAmount, GetScriptForDestination(stakeToAddressDest)); // add stake amount to stake-to-address vout
+        }
+    }
     signInput(coinstakeTx, keystore); // resign with correct fee estimation
 
     // Assign coinstake tx

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -68,9 +68,18 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 }
                 if (wtx.is_coinbase)
                 {
-                    // Generated
-                    sub.type = TransactionRecord::Generated;
-                    sub.debit = -wtx.debit; // Blocknet track debit amount for coinstakes
+                    if (i == 0)
+                        continue; // skip coinbase, instead track coinstake below
+                    if (wtx.tx->vout.size() > 2) { // if stake-to-address
+                        if (i == 1)
+                            continue; // skip stake-to-address coinstake vouts
+                        else if (i >= 2)
+                            sub.type = TransactionRecord::Generated;
+                    } else if (i == 1) {
+                        // Generated
+                        sub.type = TransactionRecord::Generated;
+                        sub.debit = -wtx.debit; // Blocknet track debit amount for coinstakes
+                    }
                 }
 
                 parts.append(sub);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -64,6 +64,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-walletrbf", strprintf("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)", DEFAULT_WALLET_RBF), false, OptionsCategory::WALLET);
     gArgs.AddArg("-zapwallettxes=<mode>", "Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup"
                                " (1 = keep tx meta data e.g. payment request information, 2 = drop tx meta data)", false, OptionsCategory::WALLET);
+    gArgs.AddArg("-staketoaddress", "Send all stake rewards to this wallet address", false, OptionsCategory::WALLET);
 
     gArgs.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), true, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), true, OptionsCategory::WALLET_DEBUG_TEST);


### PR DESCRIPTION
This option will send stake rewards (fees and block reward) to a specific address in the wallet. This allows automatic consolidation of rewards to a specific address.