### PR TITLE
Feature stakingprotocol v7

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -21,13 +21,6 @@
 static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
 
 /**
- * Maximum amount of time that a block timestamp is allowed to exceed the
- * current network-adjusted time before the block will be accepted on
- * the PoS protocol.
- */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME_POS = 3 * 60; // 3 minutes
-
-/**
  * Timestamp window used as a grace period by code that compares external
  * timestamps (such as timestamps passed to RPCs, or wallet key creation times)
  * to block timestamps. This should be set at least as high as

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,6 +117,7 @@ public:
         consensus.coinMaturity = 100;
         consensus.stakingV05UpgradeTime = 1569261600; // Sep 23 '19 6pm UTC
         consensus.stakingV06UpgradeTime = 1586973600; // Apr 15, 2020 6pm UTC
+        consensus.stakingV07UpgradeTime = 1591120800; // June 1, 2020 6pm UTC
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -286,6 +287,7 @@ public:
         consensus.coinMaturity = 15;
         consensus.stakingV05UpgradeTime = 1566085343; // Aug 17, 2019
         consensus.stakingV06UpgradeTime = 1581628366; // Feb 13, 2020
+        consensus.stakingV07UpgradeTime = 1587164819; // Apr 17, 2020 23:06:59 UTC
 
         pchMessageStart[0] = 0x45;
         pchMessageStart[1] = 0x76;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -92,7 +92,13 @@ struct Params {
     int64_t stakingPoSTargetTimespan{60*40};
     int64_t stakingV05UpgradeTime{0};
     int64_t stakingV06UpgradeTime{0};
-    int64_t PoSFutureBlockTimeLimit() const { return nPowTargetSpacing * 3; } // changing this will break consensus!
+    int64_t stakingV07UpgradeTime{0};
+    int64_t PoSFutureBlockTimeLimit(const int64_t blockTime) const { // changing this will break consensus!
+        if (blockTime >= stakingV07UpgradeTime)
+            return 15; // seconds in the future
+        else
+            return nPowTargetSpacing * 3;
+    }
     /** Service node parameters */
     int snMaxCollateralCount{10}; // max utxos for use with service node collateral
     /** Governance parameters */

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -382,7 +382,7 @@ bool stakeTargetHitV07(const uint256 & hashProofOfStake, const int64_t & current
     }
     const auto stakeWeightMultiplier = arith_uint256(multiplier * 100);
     // Stake weight is 1/200 of the staked input amount multiplied by the multiplier with 100 denominator removed
-    const auto bnCoinDayWeight = arith_uint256(nValueIn) * stakeWeightMultiplier / 200 / 100;
+    const auto bnCoinDayWeight = arith_uint256(nValueIn) * stakeWeightMultiplier / 100 / 100;
     // Now check if proof-of-stake hash meets target protocol
     return (UintToArith256(hashProofOfStake) < bnCoinDayWeight * bnTargetPerCoinDay);
 }

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -20,6 +20,7 @@ int64_t GetStakeModifierSelectionInterval();
 // Stake modifier selection upgrade
 bool IsProtocolV05(uint64_t nTimeTx);
 bool IsProtocolV06(uint64_t nTimeTx, const Consensus::Params & consensusParams);
+bool IsProtocolV07(uint64_t nTimeTx, const Consensus::Params & consensusParams);
 
 uint256 stakeHash(unsigned int nTimeTx, CDataStream ss, unsigned int prevoutIndex, uint256 prevoutHash,unsigned int nTimeBlockFrom);
 uint256 stakeHashV05(CDataStream ss, const unsigned int & nTimeBlockFrom, const int & blockHeight, const unsigned int & prevoutIndex, const unsigned int & nTimeTx);
@@ -28,6 +29,7 @@ uint256 stakeHashV06(CDataStream ss, const uint256 & hashBlockFrom, const unsign
 // Check whether stake kernel meets hash target
 bool stakeTargetHit(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
 bool stakeTargetHitV06(const uint256 & hashProofOfStake, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay);
+bool stakeTargetHitV07(const uint256 & hashProofOfStake, const int64_t & currentStakingTime, const int64_t & prevStakingTime, const int64_t & nValueIn, const arith_uint256 & bnTargetPerCoinDay, const int & nPowTargetSpacing);
 
 bool CheckStakeKernelHash(const CBlockIndex *pindexPrev, const CBlockIndex *pindexStake, const unsigned int & nBits,
         const CAmount & txInAmount, const COutPoint & prevout, const int64_t & nBlockTime, const unsigned int & nNonce,

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,7 +15,6 @@
 // from kernel.h
 bool IsProofOfStake(int blockHeight);
 bool CheckProofOfStake(const CBlockHeader & block, const CBlockIndex *pindexPrev, uint256 & hashProofOfStake, const Consensus::Params & consensusParams);
-bool IsProtocolV06(uint64_t nTimeTx, const Consensus::Params & consensusParams);
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader */*pblock*/, const Consensus::Params& params)
 {

--- a/src/stakemgr.cpp
+++ b/src/stakemgr.cpp
@@ -57,12 +57,12 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
     // are not present in the wallet this could waste cpu cycles. Normal staking happens every 15 seconds
     // (see below) and results in fewer cpu cycles.
     const int stakingInterval = std::max<int>(gArgs.GetArg("-staking", 15), 1);
-    const int64_t stakeSearchPeriodSeconds = params.PoSFutureBlockTimeLimit();
-    const int64_t endTime = GetAdjustedTime() + stakeSearchPeriodSeconds; // current time + seconds into future
+    auto adjustedTime = GetAdjustedTime();
+    int64_t endTime = adjustedTime + params.PoSFutureBlockTimeLimit(adjustedTime); // current time + seconds into future
     // A closed staking window means we've exhausted the search for a new stake
     const bool stakingWindowClosed = endTime <= lastUpdateTime + stakingInterval;
     const bool tipChanged = tip->nHeight != lastBlockHeight;
-    const bool staleTip = tip->nTime <= lastUpdateTime || tip->nTime < GetAdjustedTime() - params.stakeMinAge*2; // TODO Blocknet testnet could stall chain?
+    const bool staleTip = tip->nTime <= lastUpdateTime || tip->nTime < adjustedTime - params.stakeMinAge*2; // TODO Blocknet testnet could stall chain?
     if (stakingWindowClosed && !tipChanged && staleTip)
         return false; // do not process if staking window closed, tip hasn't changed, and tip time is stale
 
@@ -94,8 +94,9 @@ bool StakeMgr::Update(std::vector<std::shared_ptr<CWallet>> & wallets, const CBl
         const auto out = item.out;
         auto wallet = item.wallet;
         std::map<int64_t, std::vector<StakeCoin>> stakes;
-        const int64_t adjustedTime = GetAdjustedTime();
+        adjustedTime = GetAdjustedTime(); // update here b/c this loop could be long running process
         const auto blockTime = std::max(tip->GetBlockTime()+1, adjustedTime);
+        endTime = blockTime + params.PoSFutureBlockTimeLimit(blockTime); // current time + seconds into future
         if (!GetStakesMeetingTarget(out, wallet, tip, adjustedTime, blockTime, lastUpdateTime, endTime, stakes, params))
             continue;
         if (!stakes.empty()) {
@@ -155,7 +156,10 @@ bool StakeMgr::NextStake(std::vector<StakeCoin> & nextStakes, const CBlockIndex 
         // Find the smallest stake input that meets the protocol requirements
         for (const auto & stake : stakes) {
             // Make sure stake still meets network requirements
-            if (IsProtocolV06(stake.blockTime, chainparams.GetConsensus())) {
+            if (IsProtocolV07(stake.blockTime, chainparams.GetConsensus())) {
+                if (!stakeTargetHitV07(stake.hashProofOfStake, stake.time, tip->nNonce, stake.coin->txout.nValue, bnTargetPerCoinDay, chainparams.GetConsensus().nPowTargetSpacing))
+                    continue;
+            } else if (IsProtocolV06(stake.blockTime, chainparams.GetConsensus())) {
                 if (!stakeTargetHitV06(stake.hashProofOfStake, stake.coin->txout.nValue, bnTargetPerCoinDay))
                     continue;
             } else if (!stakeTargetHit(stake.hashProofOfStake, stake.coin->txout.nValue, bnTargetPerCoinDay))
@@ -275,7 +279,11 @@ bool StakeMgr::GetStakesMeetingTarget(const std::shared_ptr<COutput> & coin, std
             ss << stakeModifier;
 
             uint256 hashProofOfStake;
-            if (IsProtocolV06(blockTime, params)) {
+            if (IsProtocolV07(blockTime, params)) {
+                hashProofOfStake = stakeHashV06(ss, txInBlockHash, hashBlockTime, stakeHeight, coin->i, i);
+                if (!stakeTargetHitV07(hashProofOfStake, i, tip->nNonce, coin->GetInputCoin().txout.nValue, bnTargetPerCoinDay, params.nPowTargetSpacing))
+                    continue;
+            } else if (IsProtocolV06(blockTime, params)) {
                 hashProofOfStake = stakeHashV06(ss, txInBlockHash, hashBlockTime, stakeHeight, coin->i, i);
                 if (!stakeTargetHitV06(hashProofOfStake, coin->GetInputCoin().txout.nValue, bnTargetPerCoinDay))
                     continue;
@@ -316,4 +324,14 @@ bool StakeMgr::GetStakesMeetingTarget(const std::shared_ptr<COutput> & coin, std
     }
 
     return true;
+}
+
+void StakeMgr::Reset() {
+    {
+        LOCK(mu);
+        stakeTimes.clear();
+        stakeModifiers.clear();
+    }
+    lastUpdateTime = 0;
+    lastBlockHeight = 0;
 }

--- a/src/stakemgr.h
+++ b/src/stakemgr.h
@@ -89,6 +89,7 @@ public:
     bool GetStakesMeetingTarget(const std::shared_ptr<COutput> & coin, std::shared_ptr<CWallet> & wallet,
         const CBlockIndex *tip, const int64_t & adjustedTime, const int64_t & blockTime, const int64_t & fromTime,
         const int64_t & toTime, std::map<int64_t, std::vector<StakeCoin>> & stakes, const Consensus::Params & params);
+    void Reset();
 
 private:
     bool HasStakeModifier(const uint256 & blockHash) {

--- a/src/test/staking_tests.h
+++ b/src/test/staking_tests.h
@@ -203,8 +203,8 @@ struct TestChainPoS : public TestingSetup {
         int tries{0};
         const int currentBlockHeight = chainActive.Height();
         while (chainActive.Height() < currentBlockHeight + blockCount) {
+            CBlockIndex *pindex = nullptr;
             try {
-                CBlockIndex *pindex = nullptr;
                 {
                     LOCK(cs_main);
                     pindex = chainActive.Tip();
@@ -228,7 +228,7 @@ struct TestChainPoS : public TestingSetup {
             auto stime = staker.LastUpdateTime();
             if (stime == 0)
                 stime = GetAdjustedTime();
-            SetMockTime(stime + MAX_FUTURE_BLOCK_TIME_POS);
+            SetMockTime(stime + Params().GetConsensus().PoSFutureBlockTimeLimit(pindex->GetBlockTime()));
         }
     }
 
@@ -263,7 +263,7 @@ struct TestChainPoS : public TestingSetup {
             auto stime = staker.LastUpdateTime();
             if (stime == 0)
                 stime = GetAdjustedTime();
-            SetMockTime(stime + MAX_FUTURE_BLOCK_TIME_POS);
+            SetMockTime(stime + params.GetConsensus().PoSFutureBlockTimeLimit(tip->GetBlockTime()));
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3196,7 +3196,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.DoS(100, false, REJECT_INVALID, "bad-cs-missing", false, "second tx must be coinstake");
         // Check v6 staking protocol
         if (IsProtocolV06(block.GetBlockTime(), consensusParams)) {
-            if (block.nNonce <= 0 || block.nNonce > GetAdjustedTime() + consensusParams.PoSFutureBlockTimeLimit())
+            if (block.nNonce <= 0 || block.nNonce > GetAdjustedTime() + consensusParams.PoSFutureBlockTimeLimit(block.GetBlockTime()))
                 return state.DoS(100, false, REJECT_INVALID, "bad-cs-nonce", false, "nonce has invalid pos time");
         }
     }
@@ -3331,7 +3331,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
             return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
         // Check that stake time is valid: nonce can't be less or equal to previous block time or more than
         // future block time limit.
-        if (block.nNonce <= 0 || block.nNonce <= pindexPrev->GetBlockTime() || block.nNonce > nAdjustedTime + params.GetConsensus().PoSFutureBlockTimeLimit())
+        if (block.nNonce <= 0 || block.nNonce <= pindexPrev->GetBlockTime() || block.nNonce > nAdjustedTime + params.GetConsensus().PoSFutureBlockTimeLimit(block.GetBlockTime()))
             return state.DoS(100, false, REJECT_INVALID, "bad-cs-nonce", false, "nonce has invalid pos time");
     } else {
     // Check timestamp against prev
@@ -3340,8 +3340,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     } // end else
 
     if (IsProofOfStake(nHeight)) {
-        assert(params.GetConsensus().PoSFutureBlockTimeLimit() == MAX_FUTURE_BLOCK_TIME_POS);
-        if (block.GetBlockTime() > nAdjustedTime + params.GetConsensus().PoSFutureBlockTimeLimit())
+        if (block.GetBlockTime() > nAdjustedTime + params.GetConsensus().PoSFutureBlockTimeLimit(block.GetBlockTime()))
             return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
     } else {
     // Check timestamp


### PR DESCRIPTION
Incorporate quadratic staking weight to significantly increase
the likelihood of blocks being minted at the desired spacing.

For blocks minted prior to the target spacing:
`multiplier = n^4`

For blocks minted after the target spacing:
`multiplier = -1 * (n-2)^4 + 2`

where `n = (current_stake_nonce - last_stake_nonce) / target_spacing`