### PR TITLE
[xbridge] ShowAllOrders=true in xbridge.conf

### DIFF
--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -4,8 +4,8 @@
 
 #include <rpc/server.h>
 
-#include <xbridge/util/settings.h>
 #include <xbridge/util/logger.h>
+#include <xbridge/util/settings.h>
 #include <xbridge/util/xbridgeerror.h>
 #include <xbridge/util/xseries.h>
 #include <xbridge/util/xutil.h>
@@ -207,6 +207,8 @@ UniValue dxLoadXBridgeConf(const JSONRPCRequest& request)
     auto success = app.loadSettings();
     app.clearBadWallets(); // clear any bad wallet designations b/c user is explicitly requesting a wallet update
     app.updateActiveWallets();
+    if (!settings().showAllOrders())
+        app.clearNonLocalOrders();
     return uret(success);
 }
 
@@ -307,7 +309,7 @@ UniValue dxGetOrders(const JSONRPCRequest& request)
     auto &xapp = xbridge::App::instance();
     TransactionMap trlist = xapp.transactions();
     auto currentTime = boost::posix_time::second_clock::universal_time();
-    bool nowalletswitch = gArgs.GetBoolArg("-dxnowallets", false);
+    bool nowalletswitch = gArgs.GetBoolArg("-dxnowallets", settings().showAllOrders());
     Array result;
     for (const auto& trEntry : trlist) {
 

--- a/src/xbridge/util/settings.h
+++ b/src/xbridge/util/settings.h
@@ -35,6 +35,7 @@ public:
 public:
     bool isFullLog()
         { return get<bool>("Main.FullLog", false); }
+    bool showAllOrders() { return get<bool>("Main.ShowAllOrders", false); }
 
     bool isExchangeEnabled() const { return m_isExchangeEnabled; }
     std::string appPath() const    { return m_appPath; }

--- a/src/xbridge/xbridgeapp.h
+++ b/src/xbridge/xbridgeapp.h
@@ -525,6 +525,11 @@ public:
     }
 
     /**
+     * @brief Clears the non-local orders.
+     */
+    void clearNonLocalOrders();
+
+    /**
      * @brief Returns true if wallet update checks are already in progress, otherwise returns false.
      * @return
      */

--- a/src/xbridge/xbridgesession.cpp
+++ b/src/xbridge/xbridgesession.cpp
@@ -12,6 +12,7 @@
 #include <xbridge/util/posixtimeconversion.h>
 #include <xbridge/util/xutil.h>
 #include <xbridge/util/logger.h>
+#include <xbridge/util/settings.h>
 #include <xbridge/util/txlog.h>
 #include <xbridge/util/xassert.h>
 #include <xbridge/xbitcointransaction.h>
@@ -723,7 +724,7 @@ bool Session::Impl::processPendingTransaction(XBridgePacketPtr packet) const
 
     WalletConnectorPtr sconn = xapp.connectorByCurrency(scurrency);
     WalletConnectorPtr dconn = xapp.connectorByCurrency(dcurrency);
-    bool nowalletswitch = gArgs.GetBoolArg("-dxnowallets", false);
+    bool nowalletswitch = gArgs.GetBoolArg("-dxnowallets", settings().showAllOrders());
     if ((!sconn || !dconn) && !nowalletswitch)
     {
         xbridge::LogOrderMsg(txid.GetHex(), "no connector for <" + (!sconn ? scurrency : dcurrency) + ">", __FUNCTION__);


### PR DESCRIPTION
Added support for `ShowAllOrders=true` to xbridge.conf. Enabling this will allow viewing orders from non-local tokens without restarting the client. `-dxnowallets=` in blocknet.conf will take precedence over this setting.