### PR TITLE
Fix xbridge snode selection

### DIFF
--- a/src/xbridge/xbridgetransactiondescr.h
+++ b/src/xbridge/xbridgetransactiondescr.h
@@ -477,6 +477,11 @@ struct TransactionDescr
         return historical;
     }
 
+    void setUpdateTime(const boost::posix_time::ptime t) {
+        LOCK(_lock);
+        txtime = t;
+    }
+
     std::set<wallet::UtxoEntry> utxos() {
         LOCK(_lock);
         return {usedCoins.begin(), usedCoins.end()};


### PR DESCRIPTION
XBridge will select a new snode if order is canceled while in the Open or New states, or if the snode goes offline.