### PR TITLE
Wrong type for boost seconds, missing deque header

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <deque>
 
 #include <httpserver.h>
 

--- a/src/xbridge/xbridgeapp.cpp
+++ b/src/xbridge/xbridgeapp.cpp
@@ -84,10 +84,7 @@ class App::Impl
 {
     friend class App;
 
-    enum
-    {
-        TIMER_INTERVAL = 15
-    };
+    long TIMER_INTERVAL = 15;
 
 protected:
     /**


### PR DESCRIPTION
I was unable to build blocknet on my system without these changes.

Building with:

`./configure --enable-cxx --disable-shared --with-pic --disable-wallet --with-gui=no --enable-debug --without-miniupnpc`

Using:

* linux 5.8.7 (arch)
* gcc/g++ 10.2.0
* boost 1.72.0