### PR TITLE
copyright text on wallet splash screen was fixed

### DIFF
--- a/src/qt/blocknetsplashscreen.cpp
+++ b/src/qt/blocknetsplashscreen.cpp
@@ -38,7 +38,7 @@ BlocknetSplashScreen::BlocknetSplashScreen(interfaces::Node& node, Qt::WindowFla
     QString titleText = tr(PACKAGE_NAME);
     QString versionText = QString(tr("Version %1")).arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightTextBtc = QChar(0xA9) + QString(" 2009-2019 ") + QString(tr("The Bitcoin Core developers"));
-    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2020 ") + QString(tr("The Blocknet developers"));
+    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2021 ") + QString(tr("The Blocknet developers"));
     const QString &titleAddText = networkStyle->getTitleAddText();
 
     QString font = QApplication::font().toString();


### PR DESCRIPTION

Copyright text was changed from "2014-2019 The Blocknet developers" to "2014-2021 The Blocknet developers"

Run Blocknet wallet and check out that info at lower-left corner on splash screen

![image](https://user-images.githubusercontent.com/22638119/115799280-ca7b1d80-a3e0-11eb-97ea-af8f61c95481.png)
