### PR TITLE
add check (min_size > maker_size) condition

### DIFF
--- a/src/xbridge/xbridgesession.cpp
+++ b/src/xbridge/xbridgesession.cpp
@@ -481,6 +481,11 @@ bool Session::Impl::processTransaction(XBridgePacketPtr packet) const
     uint32_t utxoItemsCount = *static_cast<uint32_t *>(static_cast<void *>(packet->data()+offset));
     offset += sizeof(uint32_t);
 
+    if (isPartialOrder && minFromAmount > samount) {
+        xbridge::LogOrderMsg(id.GetHex(), "rejecting order, maker size can't be less than minimum size", __FUNCTION__);
+        return true;
+    }
+
     if (isPartialOrder && utxoItemsCount > xBridgePartialOrderMaxUtxos) {
         xbridge::LogOrderMsg(id.GetHex(), "rejecting order, partial order has too many utxos", __FUNCTION__);
         return true;

--- a/src/xbridge/xbridgesession.cpp
+++ b/src/xbridge/xbridgesession.cpp
@@ -482,7 +482,7 @@ bool Session::Impl::processTransaction(XBridgePacketPtr packet) const
     offset += sizeof(uint32_t);
 
     if (isPartialOrder && minFromAmount > samount) {
-        xbridge::LogOrderMsg(id.GetHex(), "rejecting order, maker size can't be less than minimum size", __FUNCTION__);
+        xbridge::LogOrderMsg(id.GetHex(), "rejecting order, minimum size cannot be greater than maker size", __FUNCTION__);
         return true;
     }
 


### PR DESCRIPTION
Scenario:

When a user posts a partial order via CLI or wallet console, XBridge is currently allowing orders where minimum_size to be > maker_size.

This shouldn't be possible as minimum_size should be a percentage (0-100%) of the maker_size.

Request parameters: dxMakePartialOrder [maker] [maker_size] [maker_address] [taker] [taker_size] [taker_address] [minimum_size] repost dryrun

Steps to reproduce:

Place a 'partial order' via the wallet console or CLI where maker_size > min_size:

Example command: dxMakePartialOrder BLOCK 1 Bch1hVnEvUiLZvQkir3HDT85LHz6CxZUR LTC 0.025135 LbnY5xWQGF5Er2MeiufauNDWtVZaV4udiE 1.1 true

Current behaviour:

Order accepted by Snode

Expected:

Order should be canceled by Snode