### PR TITLE
add case-insensitive comparison server.cpp

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <memory> // for unique_ptr
 #include <unordered_map>
@@ -189,7 +190,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
     {
         const CRPCCommand *pcmd = command.second;
         std::string strMethod = pcmd->name;
-        if ((strCommand != "" || pcmd->category == "hidden") && strMethod != strCommand)
+        if ((strCommand != "" || pcmd->category == "hidden") && !boost::iequals(strMethod, strCommand))
             continue;
         jreq.strMethod = strMethod;
         try


### PR DESCRIPTION
should work with both cases. Example:
 “help dxGetOrders”
 “help dxgetorders”
In both cases should works well