### PR TITLE
case insensitive tickers comparison

### DIFF
--- a/src/xbridge/rpcxbridge.cpp
+++ b/src/xbridge/rpcxbridge.cpp
@@ -33,6 +33,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 using namespace json_spirit;
 using namespace std;
@@ -1519,7 +1520,9 @@ UniValue dxGetOrderBook(const JSONRPCRequest& request)
                   + HelpExampleRpc("dxGetOrderBook", "3, \"BLOCK\", \"LTC\", 60")
                 },
             }.ToString());
-    Value js; json_spirit::read_string(request.params.write(), js); Array params = js.get_array();
+    Value js; 
+    json_spirit::read_string(request.params.write(), js); 
+    Array params = js.get_array();
 
     if ((params.size() < 3 || params.size() > 4))
     {
@@ -1588,8 +1591,8 @@ UniValue dxGetOrderBook(const JSONRPCRequest& request)
             if (transaction.second->state != xbridge::TransactionDescr::trPending)
                 return false;
 
-            return  ((transaction.second->toCurrency == toCurrency) &&
-                    (transaction.second->fromCurrency == fromCurrency));
+            return  ( boost::iequals(transaction.second->toCurrency, toCurrency) &&
+                      boost::iequals(transaction.second->fromCurrency, fromCurrency) );
         });
 
         // bid orders are based in the second token in the trading pair (inverse of asks)
@@ -1603,8 +1606,8 @@ UniValue dxGetOrderBook(const JSONRPCRequest& request)
             if (transaction.second->state != xbridge::TransactionDescr::trPending)
                 return false;
 
-            return  ((transaction.second->toCurrency == fromCurrency) &&
-                    (transaction.second->fromCurrency == toCurrency));
+            return  ( boost::iequals(transaction.second->toCurrency, fromCurrency) &&
+                      boost::iequals(transaction.second->fromCurrency, toCurrency));
         });
 
         std::vector<xbridge::TransactionDescrPtr> asksVector;


### PR DESCRIPTION
Run dxgetorderbook command in cli or terminal in blocknet-qt with different case tickers.
Examples:

    dxgetorderbook 1 BLOCK LTC
    dxgetorderbook 1 block ltc
    dxgetorderbook 1 block LTC
    dxgetorderbook 1 BLock ltC

All cases should work well.