### PR TITLE
copyright text on wallet splash screen was fixed

### DIFF
--- a/src/qt/blocknetsplashscreen.cpp
+++ b/src/qt/blocknetsplashscreen.cpp
@@ -38,7 +38,7 @@ BlocknetSplashScreen::BlocknetSplashScreen(interfaces::Node& node, Qt::WindowFla
     QString titleText = tr(PACKAGE_NAME);
     QString versionText = QString(tr("Version %1")).arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightTextBtc = QChar(0xA9) + QString(" 2009-2019 ") + QString(tr("The Bitcoin Core developers"));
-    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2020 ") + QString(tr("The Blocknet developers"));
+    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2021 ") + QString(tr("The Blocknet developers"));
     const QString &titleAddText = networkStyle->getTitleAddText();
 
     QString font = QApplication::font().toString();


### PR DESCRIPTION
 the copyright info on the loading screen needs updating.

Currently: © 2014-2020 The Blocknet developers

Update to: © 2014-2021 The Blocknet developers
![image](https://user-images.githubusercontent.com/22638119/122907755-22d88800-d35c-11eb-96b0-f3fcf38e1af7.png)
