### PR TITLE
Qt and readme copyright info update

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2009-2019 The Bitcoin Core developers
-Copyright (c) 2014-2020 Blocknet developers
+Copyright (c) 2014-2021 Blocknet developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ information or see https://opensource.org/licenses/MIT.
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2020 The Blocknet Developers
+Copyright (c) 2014-2021 The Blocknet Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -595,7 +595,7 @@ std::string LicenseInfo()
     const std::string URL_SOURCE_CODE = "<https://github.com/blocknetdx/blocknet>";
     const std::string URL_WEBSITE = "<https://blocknet.co>";
     const std::string copyrightText = "Copyright (c) 2009-2019 The Bitcoin Core developers\n"
-                                      "Copyright (c) 2014-2020 The Blocknet developers";
+                                      "Copyright (c) 2014-2021 The Blocknet developers";
 
     return copyrightText + "\n" +
            "\n" +

--- a/src/qt/blocknetsplashscreen.cpp
+++ b/src/qt/blocknetsplashscreen.cpp
@@ -38,7 +38,7 @@ BlocknetSplashScreen::BlocknetSplashScreen(interfaces::Node& node, Qt::WindowFla
     QString titleText = tr(PACKAGE_NAME);
     QString versionText = QString(tr("Version %1")).arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightTextBtc = QChar(0xA9) + QString(" 2009-2019 ") + QString(tr("The Bitcoin Core developers"));
-    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2020 ") + QString(tr("The Blocknet developers"));
+    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2021 ") + QString(tr("The Blocknet developers"));
     const QString &titleAddText = networkStyle->getTitleAddText();
 
     QString font = QApplication::font().toString();

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -43,7 +43,7 @@ SplashScreen::SplashScreen(interfaces::Node& node, Qt::WindowFlags f, const Netw
     QString titleText       = PACKAGE_NAME;
     QString versionText     = QString("Version %1").arg(QString::fromStdString(FormatFullVersion()));
     QString copyrightTextBtc = QChar(0xA9) + QString(" 2009-2019 ") + QString(tr("The Bitcoin Core developers"));
-    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2020 ") + QString(tr("The Blocknet developers"));
+    QString copyrightTextBlocknet = QChar(0xA9) + QString(" 2014-2021 ") + QString(tr("The Blocknet developers"));
     QString copyrightText   = copyrightTextBtc + QString("\n") + copyrightTextBlocknet;
     QString titleAddText    = networkStyle->getTitleAddText();
 


### PR DESCRIPTION
Change all Blocknet Qt and Classic GUI references of 2014-2020 to 2014-2021